### PR TITLE
Avoid invalid reads in fromQString().

### DIFF
--- a/qocoa_mac.h
+++ b/qocoa_mac.h
@@ -27,7 +27,8 @@ THE SOFTWARE.
 
 static inline NSString* fromQString(const QString &string)
 {
-    char* cString = string.toUtf8().data();
+    const QByteArray utf8 = string.toUtf8();
+    const char* cString = utf8.constData();
     return [[NSString alloc] initWithUTF8String:cString];
 }
 


### PR DESCRIPTION
Don't keep pointer to temporary. The QByteArray from toUtf8() is destroyed after the statement. Silences Valgrind.
