### PR TITLE
Port Qocoa to Qt5

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
-#include <QtGui/QApplication>
+#include <QApplication>
+
 #include "gallery.h"
 
 int main(int argc, char *argv[])

--- a/qocoa_mac.h
+++ b/qocoa_mac.h
@@ -20,10 +20,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <AppKit/NSImage.h>
 #include <Foundation/NSString.h>
 #include <QString>
 #include <QVBoxLayout>
 #include <QMacCocoaViewContainer>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#include <qmacfunctions.h>
+#endif
 
 static inline NSString* fromQString(const QString &string)
 {
@@ -41,11 +46,15 @@ static inline QString toQString(NSString *string)
 
 static inline NSImage* fromQPixmap(const QPixmap &pixmap)
 {
+#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
     CGImageRef cgImage = pixmap.toMacCGImageRef();
+#else
+    CGImageRef cgImage = QtMac::toCGImageRef(pixmap);
+#endif
     return [[NSImage alloc] initWithCGImage:cgImage size:NSZeroSize];
 }
 
-static inline void setupLayout(void *cocoaView, QWidget *parent)
+static inline void setupLayout(NSView *cocoaView, QWidget *parent)
 {
     parent->setAttribute(Qt::WA_NativeWindow);
     QVBoxLayout *layout = new QVBoxLayout(parent);

--- a/qsearchfield_mac.mm
+++ b/qsearchfield_mac.mm
@@ -156,7 +156,12 @@ void QSearchField::setMenu(QMenu *menu)
     if (!pimpl)
         return;
 
+#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
     NSMenu *nsMenu = menu->macMenu();
+#else
+    NSMenu *nsMenu = menu->toNSMenu();
+#endif
+
     [[pimpl->nsSearchField cell] setSearchMenuTemplate:nsMenu];
 }
 


### PR DESCRIPTION
Makes Qocoa compile against Qt 5, tested with
Qt 5.2.0 and OS X 10.9. It requires QtMacExtras for
QtMac::toCGImageRef().

I left out CMakeLists.txt changes so far as I'm unsure how you prefer Qt4 vs. Qt5 to be handled in there.
