### PR TITLE
travis.yml: (ab)use objective-c language for OS X.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,27 @@
-language: cpp
-os:
-  - linux
-  - osx
-env:
-  - XMAKE=qmake
-  - XMAKE=cmake
+language: objective-c
+os: osx
+matrix:
+  include:
+    - compiler: clang
+      env:
+        - XMAKE=qmake
+    - compiler: clang
+      env:
+        - XMAKE=cmake
+        - XMAKE_OPTIONS="."
+    - compiler: clang
+      env:
+        - XMAKE=qmake
+        - XMAKE_OPTIONS="NON_MAC_WIDGETS=1"
+    - compiler: gcc
+      env:
+        - XMAKE=cmake
+        - XMAKE_OPTIONS=". -DNON_MAC_WIDGETS=ON"
+        - CC=gcc-4.9
+        - CXX=g++-4.9
 before_install:
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update; fi
-  - if [ $TRAVIS_OS_NAME = osx ];   then brew update; fi
+  - brew update
 install:
-  - if [ $TRAVIS_OS_NAME = linux ] && [ $XMAKE = cmake ]; then sudo apt-get install -y cmake; fi
-  - if [ $TRAVIS_OS_NAME = linux ];                       then sudo apt-get install -y libqt4-dev qt4-qmake; fi
-  - if [ $TRAVIS_OS_NAME = osx ]   && [ $XMAKE = cmake ]; then brew install cmake; fi
-  - if [ $TRAVIS_OS_NAME = osx ];                         then brew install qt; fi
+  - brew install qt
 script:
-  - $XMAKE . && make
+  - $XMAKE $XMAKE_OPTIONS && make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 project(Qocoa)
 cmake_minimum_required(VERSION 2.8)
 
+option(NON_MAC_WIDGETS "Force non-Mac widgets on OS X (useful for testing)" OFF)
+
 find_package(Qt4 COMPONENTS QtMain QtCore QtGui REQUIRED)
 include(UseQt4)
 
@@ -18,13 +20,14 @@ set(HEADERS
 
 qt4_wrap_cpp(MOC_SOURCES ${HEADERS})
 
-if(APPLE)
+if(APPLE AND NOT ${NON_MAC_WIDGETS})
     list(APPEND SOURCES
         qsearchfield_mac.mm
         qbutton_mac.mm
         qprogressindicatorspinning_mac.mm
     )
 else()
+  message(here)
     list(APPEND SOURCES
         qsearchfield_nonmac.cpp
         qbutton_nonmac.cpp
@@ -38,11 +41,11 @@ else()
 endif()
 
 add_executable(Qocoa
-    WIN32 MACOSX_BUNDLE 
+    WIN32 MACOSX_BUNDLE
     ${SOURCES} ${MOC_SOURCES} ${RESOURCES_SOURCES}
 )
 target_link_libraries(Qocoa ${QT_LIBRARIES})
 
-if(APPLE)
+if(APPLE AND NOT ${NON_MAC_WIDGETS})
     set_target_properties(Qocoa PROPERTIES LINK_FLAGS "-framework Foundation -framework AppKit")
 endif()

--- a/Qocoa.pro
+++ b/Qocoa.pro
@@ -7,11 +7,11 @@ HEADERS += gallery.h \
            qbutton.h \
            qprogressindicatorspinning.h \
 
-mac {
+!mac|equals(NON_MAC_WIDGETS, 1) { {
+    SOURCES += qsearchfield_nonmac.cpp qbutton_nonmac.cpp qprogressindicatorspinning_nonmac.cpp
+    RESOURCES += qsearchfield_nonmac.qrc qprogressindicatorspinning_nonmac.qrc
+} else {
     OBJECTIVE_SOURCES += qsearchfield_mac.mm qbutton_mac.mm qprogressindicatorspinning_mac.mm
     LIBS += -framework Foundation -framework Appkit
     QMAKE_CFLAGS += -mmacosx-version-min=10.6
-} else {
-    SOURCES += qsearchfield_nonmac.cpp qbutton_nonmac.cpp qprogressindicatorspinning_nonmac.cpp
-    RESOURCES += qsearchfield_nonmac.qrc qprogressindicatorspinning_nonmac.qrc
 }


### PR DESCRIPTION
This allows us to force Mac builds.

Also:

- add options to the CMake and QMake build systems so we can verify that
  the non-Mac files still compile OK
- compile with GCC in CMake for the non-Mac files
