### PR TITLE
Use Cocoa actions for search field copy/cut/paste instead of trying t…

### DIFF
--- a/qsearchfield_mac.mm
+++ b/qsearchfield_mac.mm
@@ -145,21 +145,17 @@ public:
             }
             else if (keyString == "c")  // Cmd+c
             {
-                QClipboard* clipboard = QApplication::clipboard();
-                clipboard->setText(toQString([self stringValue]));
+                [[self currentEditor] copy: nil];
                 return YES;
             }
             else if (keyString == "v")  // Cmd+v
             {
-                QClipboard* clipboard = QApplication::clipboard();
-                [self setStringValue:fromQString(clipboard->text())];
+                [[self currentEditor] paste: nil];
                 return YES;
             }
             else if (keyString == "x")  // Cmd+x
             {
-                QClipboard* clipboard = QApplication::clipboard();
-                clipboard->setText(toQString([self stringValue]));
-                [self setStringValue:@""];
+                [[self currentEditor] cut: nil];
                 return YES;
             }
         }


### PR DESCRIPTION
…o reimplement the same thing with some Qt.

So unlike previously, actions now also works as expected if some part of the text is selected, or if some text is already present (for paste action: doesn't replace previous text)